### PR TITLE
work in progress using mongo native driver and promises

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,4 +1,7 @@
-SLACK_ID=your.id
-SLACK_SECRET=yourslacksecret
-SLACK_REDIRECT=http://localhost:5000/
+# edit this and rename it to .env
+
 PORT=5000
+SLACK_ID=XXX
+SLACK_SECRET=XXX
+SLACK_REDIRECT=http://localhost:5000/
+MONGO_URI=mongodb://localhost/YOURAPPNAME

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,335 @@
+{
+	"ecmaFeatures": {
+		"jsx": true
+	},
+	"env": {
+		"browser": true,
+		"mocha": true,
+		"node": true,
+		"meteor": true,
+	},
+	"parser": "babel-eslint",
+	"plugins": [
+		"react"
+	],
+	"globals": {
+		"window": true,
+		"$": true,
+		"ga": true,
+		"jQuery": true,
+		"router": true,
+
+		/* config */
+		"AppConfig": true,
+		"ServerConfig": true,
+
+		/* utils */
+		"dclib": true,
+		"Logger": true,
+
+		/* collections */
+		"Chatlogs": true,
+		"KBase": true,
+		"Players": true,
+		"ChatResponse": true,
+		"Grammar": true,
+		"Examples": true,
+		"Topics": true,
+		"BotVars": true,
+		"HelpFlags": true,
+		"Media": true,
+
+		/* lib */
+		"FormatMessage": true,
+		"SendMessage": true,
+		"Message": true,
+
+
+		/* react components */
+		"AppTheme": true,
+		"ChatAdminComponent": true,
+		"ChatlogRowComponent": true,
+		"AdminComponent": true,
+		"ChatlogsComponent": true,
+		"KbItemComponent": true,
+		"KBaseComponent": true,
+		"FormatUtils": true,
+		"PlayerListComponent": true,
+		"WechatTokens": true,
+		"WechatAPI": true,
+		"WechatObject": true,
+
+		"LogReviewComponent": true,
+		"MainLayout": true,
+		"PopupBar": true,
+
+		"TopComponent": true,
+		"HomeComponent": true,
+		"PlayerInfoComponent": true,
+		"PlayerCard": true,
+		"TopicMenuContainer": true,
+		"TopicList": true,
+		"LogTableComponent": true,
+		"RiveTriggerList": true,
+		"ChatLogger": true,
+		"AgentInputBox": true,
+		"UserInputBox": true,
+		"ChatCommands": true,
+		"TestLib": true,
+		"TopicInfoCard": true,
+		"LiveEditor": true,
+
+		"ToggleParamComponent": true,
+		"ToggleParamMenu": true,
+		"TopicListField": true,
+		"RebotTopics": true,
+
+		"InterChat": true,
+		"WhoMenu": true,
+		"LessonEditor": true,
+		"LessonList": true,
+		"LessonDetail": true,
+
+
+		/* libs and packages */
+		"Picker": true,
+		"Rebot": true,
+		"RiveScript": true,
+		"WechatObject": true,
+		"ChatRobot": true,
+
+		/* vendor */
+		"ReactMeteorData": true,
+		"FlowRouter": true,
+		"React": true,
+		"ReactDOM": true,
+		"ReactLayout": true,
+		"MUI": true,
+		"Handsontable": true
+
+
+	},
+	"rules": {
+		"comma-dangle": 0,
+		"no-cond-assign": 2,
+		"no-console": 0,
+		"no-constant-condition": 2,
+		"no-control-regex": 2,
+		"no-debugger": 2,
+		"no-dupe-keys": 2,
+		"no-empty": 2,
+		"no-empty-character-class": 2,
+		"no-ex-assign": 2,
+		"no-extra-boolean-cast": 2,
+		"no-extra-parens": 0,
+		"no-extra-semi": 2,
+		"no-func-assign": 2,
+		"no-inner-declarations": 2,
+		"no-invalid-regexp": 2,
+		"no-irregular-whitespace": 0,
+		"no-negated-in-lhs": 2,
+		"no-obj-calls": 2,
+		"no-regex-spaces": 2,
+		"no-reserved-keys": 0,
+		"no-sparse-arrays": 2,
+		"no-unreachable": 2,
+		"use-isnan": 2,
+		"valid-jsdoc": 2,
+		"valid-typeof": 2,
+
+		"block-scoped-var": 0,
+		"complexity": 0,
+		"consistent-return": 2,
+		"curly": 2,
+		"default-case": 1,
+		"dot-notation": 0,
+		"eqeqeq": 1,
+		"guard-for-in": 1,
+		"no-alert": 1,
+		"no-caller": 2,
+		"no-div-regex": 2,
+		"no-else-return": 0,
+		"no-empty-label": 2,
+		"no-eq-null": 1,
+		"no-eval": 2,
+		"no-extend-native": 0,
+		"no-extra-bind": 2,
+		"no-fallthrough": 1,
+		"no-floating-decimal": 2,
+		"no-implied-eval": 2,
+		"no-iterator": 2,
+		"no-labels": 2,
+		"no-lone-blocks": 2,
+		"no-loop-func": 1,
+		"no-multi-spaces": 0,
+		"no-multi-str": 2,
+		"no-native-reassign": 2,
+		"no-new": 2,
+		"no-new-func": 2,
+		"no-new-wrappers": 2,
+		"no-octal": 2,
+		"no-octal-escape": 2,
+		"no-process-env": 0,
+		"no-proto": 2,
+		"no-redeclare": 1,
+		"no-return-assign": 2,
+		"no-script-url": 2,
+		"no-self-compare": 2,
+		"no-sequences": 2,
+		"no-unused-expressions": 2,
+		"no-void": 1,
+		"no-warning-comments": [
+			0,
+			{
+				"terms": [
+					"fixme"
+				],
+				"location": "start"
+			}
+		],
+		"no-with": 2,
+		"radix": 2,
+		"vars-on-top": 0,
+		"wrap-iife": [2, "any"],
+		"yoda": 0,
+
+		"strict": 0,
+
+		"no-catch-shadow": 2,
+		"no-delete-var": 2,
+		"no-label-var": 2,
+		"no-shadow": 0,
+		"no-shadow-restricted-names": 2,
+		"no-undef": 2,
+		"no-undef-init": 2,
+		"no-undefined": 1,
+		"no-unused-vars": 0,
+		"no-use-before-define": 0,
+
+		"handle-callback-err": 1,
+		"no-mixed-requires": 0,
+		"no-new-require": 2,
+		"no-path-concat": 2,
+		"no-process-exit": 0,
+		"no-restricted-modules": 0,
+		"no-sync": 0,
+
+		"brace-style": [
+			2,
+			"1tbs",
+			{ "allowSingleLine": true }
+		],
+		"camelcase": 0,
+		"comma-spacing": [
+			2,
+			{
+				"before": false,
+				"after": true
+			}
+		],
+		"comma-style": [
+			2, "last"
+		],
+		"consistent-this": 0,
+		"eol-last": 2,
+		"func-names": 0,
+		"func-style": 0,
+		"key-spacing": [
+			0,
+			{
+				"beforeColon": false,
+				"afterColon": true
+			}
+		],
+		"max-nested-callbacks": 0,
+		"new-cap": 0,
+		"new-parens": 2,
+		"no-array-constructor": 2,
+		"no-inline-comments": 0,
+		"no-lonely-if": 1,
+		"no-mixed-spaces-and-tabs": 2,
+		"no-multiple-empty-lines": [
+			2,
+			{ "max": 3 }
+		],
+		"no-nested-ternary": 2,
+		"no-new-object": 2,
+		"semi-spacing": [2, { "before": false, "after": true }],
+		"no-spaced-func": 2,
+		"no-ternary": 0,
+		"no-trailing-spaces": 1,
+		"no-underscore-dangle": 0,
+		"one-var": 0,
+		"operator-assignment": 0,
+		"padded-blocks": 0,
+		"quote-props": 0,
+		"quotes": [
+			0,
+			"single",
+			"avoid-escape"
+		],
+		"semi": [
+			2,
+			"always"
+		],
+		"sort-vars": 0,
+		"space-after-keywords": [
+			2,
+			"always"
+		],
+		"space-before-function-paren": [
+			2,
+			"never"
+		],
+		"space-before-blocks": [
+			2,
+			"always"
+		],
+		"space-in-brackets": 0,
+		"space-in-parens": 0,
+		"space-infix-ops": 2,
+		"space-return-throw-case": 2,
+		"space-unary-ops": [
+			1,
+			{
+				"words": true,
+				"nonwords": false
+			}
+		],
+		"spaced-comment": [
+			2,
+			"always",
+			{ "exceptions": ["-"] }
+		],
+		"wrap-regex": 1,
+
+		"max-depth": 0,
+		"max-len": [
+			0,
+			150,
+			2
+		],
+		"max-params": 0,
+		"max-statements": 0,
+		"no-bitwise": 1,
+		"no-plusplus": 0,
+
+		"react/display-name": 0,
+		"react/jsx-boolean-value": [1, "always"],
+		"react/jsx-no-undef": 1,
+		"react/jsx-sort-props": 0,
+		"react/jsx-uses-react": 1,
+		"react/jsx-uses-vars": 1,
+		"react/no-did-mount-set-state": 2,
+		"react/no-did-update-set-state": 2,
+		"react/no-multi-comp": 2,
+		"react/prop-types": 2,
+		"react/react-in-jsx-scope": 0,
+		"react/self-closing-comp": 1,
+		"react/wrap-multilines": 1,
+
+    /* dc adds */
+    /* http://eslint.org/docs/rules/require-yield */
+    "require-yield": 1
+	}
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env
+node_modules

--- a/app/controllers/botkit.js
+++ b/app/controllers/botkit.js
@@ -17,6 +17,9 @@ const config = {mongoUri: mongoUri};
 let Storage = require('../../config/storage/mongo');
 let db = Storage.connect(config);
 
+// FIXME
+// this is exported so has to be scoped here and available when the file is required
+// but promises aren't ready just at initial require/parse time.
 let controller;
 
 db.then(function() {
@@ -30,119 +33,120 @@ db.then(function() {
       storage: botkit_mongo_storage
     });
 
-    // CONNECTION FUNCTIONS=====================================================
-    exports.connect = function(team_config) {
-      var bot = controller.spawn(team_config);
-      controller.trigger('create_bot', [bot, team_config]);
-    };
+    // just a simple way to make sure we don't
+    // connect to the RTM twice for the same team
+    var _bots = {};
 
+    function trackBot(bot) {
+      _bots[bot.config.token] = bot;
+    }
 
+    controller.on('create_bot', function(bot, team) {
 
-// just a simple way to make sure we don't
-// connect to the RTM twice for the same team
-var _bots = {};
+      if (_bots[bot.config.token]) {
+        // already online! do nothing.
+        console.log("already online! do nothing.");
+      } else {
+        bot.startRTM(function(err) {
 
-function trackBot(bot) {
-  _bots[bot.config.token] = bot;
-}
+          if (!err) {
+            trackBot(bot);
 
-controller.on('create_bot', function(bot, team) {
+            console.log("RTM ok")
 
-  if (_bots[bot.config.token]) {
-    // already online! do nothing.
-    console.log("already online! do nothing.");
-  } else {
-    bot.startRTM(function(err) {
-
-      if (!err) {
-        trackBot(bot);
-
-        console.log("RTM ok")
-
-        controller.saveTeam(team, function(err, id) {
-          if (err) {
-            console.log("Error saving team")
+            controller.saveTeam(team, function(err, id) {
+              if (err) {
+                console.log("Error saving team")
+              }
+              else {
+                console.log("Team " + team.name + " saved")
+              }
+            })
           }
-          else {
-            console.log("Team " + team.name + " saved")
+
+          else{
+            console.log("RTM failed")
           }
-        })
-      }
 
-      else{
-        console.log("RTM failed")
-      }
+          bot.startPrivateConversation({user: team.createdBy},function(err,convo) {
+            if (err) {
+              console.log(err);
+            } else {
+              convo.say('I am a bot that has just joined your team');
+              convo.say('You must now /invite me to a channel so that I can be of use!');
+            }
+          });
 
-      bot.startPrivateConversation({user: team.createdBy},function(err,convo) {
-        if (err) {
-          console.log(err);
-        } else {
-          convo.say('I am a bot that has just joined your team');
-          convo.say('You must now /invite me to a channel so that I can be of use!');
-        }
+        });
+      }
+    });
+
+    //REACTIONS TO EVENTS==========================================================
+
+    // Handle events related to the websocket connection to Slack
+    controller.on('rtm_open',function(bot) {
+      console.log('** The RTM api just connected!');
+    });
+
+    controller.on('rtm_close',function(bot) {
+      console.log('** The RTM api just closed');
+      // you may want to attempt to re-open
+    });
+
+    //DIALOG ======================================================================
+
+    controller.hears('hello','direct_message',function(bot,message) {
+      bot.reply(message,'Hello!');
+    });
+
+    controller.hears('^stop','direct_message',function(bot,message) {
+      bot.reply(message,'Goodbye');
+      bot.rtm.close();
+    });
+
+    controller.on('direct_message,mention,direct_mention',function(bot,message) {
+      bot.api.reactions.add({
+        timestamp: message.ts,
+        channel: message.channel,
+        name: 'robot_face',
+      },function(err) {
+        if (err) { console.log(err) }
+        bot.reply(message,'I heard you loud and clear boss.');
       });
+    });
+
+    controller.storage.teams.all(function(err,teams) {
+
+      console.log(teams)
+
+      if (err) {
+        throw new Error(err);
+      }
+
+      // connect all teams with bots up to slack!
+      for (var t  in teams) {
+        if (teams[t].bot) {
+          var bot = controller.spawn(teams[t]).startRTM(function(err) {
+            if (err) {
+              console.log('Error connecting bot to Slack:',err);
+            } else {
+              trackBot(bot);
+            }
+          });
+        }
+      }
 
     });
-  }
-});
 
-//REACTIONS TO EVENTS==========================================================
-
-// Handle events related to the websocket connection to Slack
-controller.on('rtm_open',function(bot) {
-  console.log('** The RTM api just connected!');
-});
-
-controller.on('rtm_close',function(bot) {
-  console.log('** The RTM api just closed');
-  // you may want to attempt to re-open
-});
-
-//DIALOG ======================================================================
-
-controller.hears('hello','direct_message',function(bot,message) {
-  bot.reply(message,'Hello!');
-});
-
-controller.hears('^stop','direct_message',function(bot,message) {
-  bot.reply(message,'Goodbye');
-  bot.rtm.close();
-});
-
-controller.on('direct_message,mention,direct_mention',function(bot,message) {
-  bot.api.reactions.add({
-    timestamp: message.ts,
-    channel: message.channel,
-    name: 'robot_face',
-  },function(err) {
-    if (err) { console.log(err) }
-    bot.reply(message,'I heard you loud and clear boss.');
-  });
-});
-
-controller.storage.teams.all(function(err,teams) {
-
-  console.log(teams)
-
-  if (err) {
-    throw new Error(err);
-  }
-
-  // connect all teams with bots up to slack!
-  for (var t  in teams) {
-    if (teams[t].bot) {
-      var bot = controller.spawn(teams[t]).startRTM(function(err) {
-        if (err) {
-          console.log('Error connecting bot to Slack:',err);
-        } else {
-          trackBot(bot);
-        }
-      });
-    }
-  }
 
 });
 
-});
+// FIXME - controller won't be ready at time this is required
+
+// CONNECTION FUNCTIONS=====================================================
+exports.connect = function(team_config) {
+  var bot = controller.spawn(team_config);
+  controller.trigger('create_bot', [bot, team_config]);
+};
 
 exports.controller = controller;

--- a/app/routes/routes.js
+++ b/app/routes/routes.js
@@ -1,6 +1,10 @@
 var Request          = require('request')
 var slack           = require('../controllers/botkit')
 
+// this is a problem as botkit is still promising
+
+console.log('init slack', slack.connect);
+
 // frontend routes =========================================================
 module.exports = function(app) {
 

--- a/bin/watch
+++ b/bin/watch
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+DEBUG=*,-express*,-nodemon* nodemon -e ejs,js,css server.js

--- a/config/storage/mongo.js
+++ b/config/storage/mongo.js
@@ -1,27 +1,41 @@
-var db = require('monk');
+'use strict';
+
+var MongoClient = require('mongodb'),
+    co = require('co'),
+    debug = require('debug')('mongo-storage')
+    ;
+
+let Storage = {};
+
 /**
  * botkit-storage-mongo - MongoDB driver for Botkit
  *
- * @param  {Object} config
- * @return {Object}
+ * @param  {Object} config Mongo config
+ * @return {Object} query result
  */
-module.exports = function(config) {
+Storage.connect = function(config) {
+    // let db = MongoStorage.init(config);
+    let db = MongoClient.connect('mongodb://localhost:27017/mongo-drivers');
+    return db;
+};
 
-    if (!config || !config.mongoUri)
-        throw new Error('Need to provide mongo address.');
+Storage.setup = function(db) {
+    debug('setup with', db);
 
-    var Teams = db(config.mongoUri).get('teams'),
-        Users = db(config.mongoUri).get('users'),
-        Channels = db(config.mongoUri).get('channels');
+    var Teams = db.collection('teams'),
+        Users = db.collection('users'),
+        Channels = db.collection('channels'),
+        Stories = db.collection('stories');
 
     var unwrapFromList = function(cb) {
         return function(err, data) {
-            if (err) return cb(err);
+            if (err) { return cb(err); }
             cb(null, data);
         };
     };
 
     var storage = {
+
         teams: {
             get: function(id, cb) {
                 Teams.findOne({id: id}, unwrapFromList(cb));
@@ -73,4 +87,6 @@ module.exports = function(config) {
     };
 
     return storage;
-};
+}
+
+module.exports = Storage;

--- a/config/storage/test-mongo.js
+++ b/config/storage/test-mongo.js
@@ -1,0 +1,43 @@
+'use strict';
+
+var assert = require('assert');
+
+const mongoUri = process.env.MONGO_URI || 'mongodb://localhost/botkit_express_demo';
+const config = {mongoUri: mongoUri};
+
+// let clog = debug;
+let clog = console.log;
+
+clog('testing');
+
+
+function testFields(configuration) {
+	clog('testFields');
+	if (
+		configuration.storage.teams &&
+		configuration.storage.teams.get &&
+		configuration.storage.teams.save &&
+
+		configuration.storage.users &&
+		configuration.storage.users.get &&
+		configuration.storage.users.save &&
+
+		configuration.storage.channels &&
+		configuration.storage.channels.get &&
+		configuration.storage.channels.save
+	) {
+		clog('** Using custom storage system.');
+	} else {
+		clog('storage required fields dont exist');
+	}
+
+}
+
+let Storage = require('./mongo');
+let db = Storage.connect(config);
+
+db.then(function() {
+	clog('connected');
+	let botkit_mongo_storage = Storage.setup(db);
+	testFields(botkit_mongo_storage);
+});

--- a/package.json
+++ b/package.json
@@ -4,18 +4,25 @@
   "description": "Demo of Botkit within an Express app, using Mongodb database",
   "main": "server.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "babel-node": "babel-node --stage 0 --ignore='foo|bar|baz'"
   },
   "author": "",
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.14.2",
-    "botkit": "0.0.5",
+    "botkit": "^*",
+    "co": "^4.6.0",
     "dotenv": "^2.0.0",
     "ejs": "^2.4.1",
     "express": "^4.13.4",
-    "mongodb": "^2.1.6",
-    "monk": "^1.0.1",
-    "request": "^2.69.0"
+    "mocha": "^2.4.5",
+    "reload": "^0.7.0",
+    "request": "^2.69.0",
+    "mongodb": "^2.1.0"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.5.1",
+    "node-inspector": "^0.12.6"
   }
 }


### PR DESCRIPTION
@mvaragnat this is for reference only

I ported to using the native mongo 2.1 driver which supports promises.
this means no deps on monk or any of those other flaky drivers.
the 2.1 mongo driver itself is fairly feature full.

mongo itself is connecting fine, and returns a promise
https://github.com/dcsan/botkit-express-demo/blob/master/app/controllers/botkit.js#L22

however, the whole initialization process of the app is just using `require(xxx)` type structure, so I'm not really sure how to get things to work without a huge refactoring to make it more promise driven.

maybe someone on the howdy team would have some ideas?

for my new code i would prefer to work with mongo in this way but don't see how to get botkit refactored.

I also did some tests with other mongo drivers and using co() and await syntax 
https://github.com/dcsan/mongo-driver-comparison/blob/master/test/es6-test.js

again this would mean some refactoring at the top level to be `co` aware...

let me know if you have any thoughts.

another way is using typescript which already supports the `await` syntax
https://github.com/dcsan/mongo-driver-comparison/blob/master/test/typescript-await-demo.ts

but not sure anyone on botkit would want to go there - it would narrow down the possible contributors a lot.
